### PR TITLE
Fixed username not displaying in sub notifications

### DIFF
--- a/modules/greetings.js
+++ b/modules/greetings.js
@@ -23,7 +23,7 @@ var onSub = (channel, user) => {
 		"Type": _consts.greeting.sub
 	}, (rows) => {
 		if(rows.length > 0){
-			_client.say(channel, formatGreetingText(rows[0].OutputText, util.getDisplayName(user)));
+			_client.say(channel, formatGreetingText(rows[0].OutputText, user));
 		}
 	});
 };
@@ -34,7 +34,7 @@ var onResub = (channel, user, months) => {
 		"Type": _consts.greeting.resub
 	}, (rows) => {
 		if(rows.length > 0){
-			_client.say(channel, formatGreetingText(rows[0].OutputText, util.getDisplayName(user), months));
+			_client.say(channel, formatGreetingText(rows[0].OutputText, user, months));
 		}
 	});
 };


### PR DESCRIPTION
The subscription/subanniversary events don't return a user object like normal messages and only the username, therefore no need need to use the function on them. I don't know if they return the display name or just the normal name with a capital at the start (I think they _do_ return the display name though) but that's on Twitch's end anyway.
